### PR TITLE
ci: 更新部署工作流触发条件

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,6 @@
 name: Build And Publish Docker Image
 
 on:
-  push:
-    branches:
-      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- 移除自动推送镜像到 Docker Hub 的配置
- 保留手动触发构建和发布镜像的功能